### PR TITLE
Remove user mapping configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 vim-bible
 =========
 
-Vim-bible is a simple vim plugin that makes it easy to insert a Bible passage 
+Vim-bible is a simple vim plugin that makes it easy to insert a Bible passage
 into vim. The plugin is inspired by [this plugin][1].
 
-At its simplest, type `<leader>b` in normal mode, enter the query, and the text 
-is inserted. You may also select a query in visual mode and run `<leader>b` to 
+At its simplest, type `<leader>b` in normal mode, enter the query, and the text
+is inserted. You may also select a query in visual mode and run `<leader>b` to
 insert the corresponding Bible passage.
 
-**Note:** You need to have Diatheke/Sword installed. This is the backend being 
+**Note:** You need to have Diatheke/Sword installed. This is the backend being
     used to extract the Bible text.
 
 
@@ -28,7 +28,7 @@ There are a few settings, which of some are required for the plugin to work.
 
 ### g:BibleTranslation
 
-This setting is required. Specify the name of the module here. If you're not 
+This setting is required. Specify the name of the module here. If you're not
 sure about the correct abbreviation, you can run:
 
     diatheke -b system -k modulelist
@@ -40,8 +40,8 @@ In your ~/.vimrc specify the translation like this:
 
 ### g:BibleFormat
 
-This is how you want the text to be formatted before inserted into the document.  
-It is formatted like a `sed` replacement string, with a few backreferences 
+This is how you want the text to be formatted before inserted into the document.
+It is formatted like a `sed` replacement string, with a few backreferences
 available:
 
   1. The name of the book
@@ -49,7 +49,7 @@ available:
   3. The verse
   4. The text itself
 
-Here are some examples of how it may look like. Note how the backreferences are 
+Here are some examples of how it may look like. Note how the backreferences are
 double escaped.
 
     :let g:BibleFormat = "\\3. \\4"
@@ -67,8 +67,8 @@ double escaped.
 
 ### g:BibleLocale
 
-The locale specifies your language (mainly used for names on books, references 
-etc.). It consists of two characters. You may try your own locale with the 
+The locale specifies your language (mainly used for names on books, references
+etc.). It consists of two characters. You may try your own locale with the
 following command:
 
     # Note how the query is language specific (swedish/sv)
@@ -81,8 +81,8 @@ In the ~/.vimrc file:
 
 ### g:BibleOmitModuleName
 
-Diatheke ends the passage with the name of the translation inside parenthesis.  
-By default vim-bible removes it. If you want to include the module name, use the 
+Diatheke ends the passage with the name of the translation inside parenthesis.
+By default vim-bible removes it. If you want to include the module name, use the
 following setting:
 
     let g:BibleOmitModuleName = 0
@@ -90,11 +90,21 @@ following setting:
 
 ### g:BibleDelimiter
 
-If you want another character than a newline between every verse, specify it 
-here. The most useful alternative is probably a regular blankspace. Might be 
+If you want another character than a newline between every verse, specify it
+here. The most useful alternative is probably a regular blankspace. Might be
 specified like this:
 
     let g:BibleDelimiter = " "
+
+
+Using the plugin
+----------------
+
+You can map the `Bible()` function as you wish. The proposed mappings are
+`<leader>b`, but you can chose what suits you best. Example:
+
+    nnoremap <leader>b y :call Bible()<CR>
+    vnoremap <leader>b y :call Bible(@*)<CR>
 
 
 Copyright & license

--- a/plugin/bible.vim
+++ b/plugin/bible.vim
@@ -1,7 +1,3 @@
-nnoremap <leader>b y :call Bible()<CR>
-vnoremap <leader>b y :call Bible(@*)<CR>
-
-
 function Bible(...)
     if !exists('g:BibleTranslation')
         echo "You must set g:BibleTranslation before using this plugin!"


### PR DESCRIPTION
The user config has been removed according to issue #3. The mappings should be delegated to the user's config instead of hardcode them within the plugin.

Also modified the readme accordingly and removed trailing white spaces from readme.