### PR TITLE
Remove html tags from diatheke output

### DIFF
--- a/autoload/bible.vim
+++ b/autoload/bible.vim
@@ -20,6 +20,7 @@ fu! bible#insert_quote(...) abort
 
     let text = system(command)
     if text !~ "^Diatheke" && text !~ "^[\s\n\r]*$"
+        let text = substitute(text, '<[^>]*>', '', 'g')
         put = text
     else
         echo "Invalid query!"


### PR DESCRIPTION
I found it really annoying that my diatheke output was covered in html tags saying which words are to be marked italic or red, etc. For example, this was the output when requesting John 3:16 from the KJV prior to this change:

```html
John 3:16: <q marker=""><milestone marker="¶" type="x-p"/><w  savlm="strong:G3588 lemma.TR:ο" src="17"/><w  savlm="strong:G3588 lemma.TR:τον" src="12"/><w  savlm="strong:G1063 lemma.TR:γαρ" src="2">For</w> <w  savlm="strong:G3588 strong:G2316 lemma.TR:ο lemma.TR:θεος" src="4 5">God</w> <w  savlm="strong:G3779 lemma.TR:ουτως" src="1">so</w> <w  savlm="strong:G25 lemma.TR:ηγαπησεν" src="3">loved</w> <w  savlm="strong:G3588 strong:G2889 lemma.TR:τον lemma.TR:κοσμον" src="6 7">the world</w>, <w  savlm="strong:G5620 lemma.TR:ωστε" src="8">that</w> <w  savlm="strong:G1325 lemma.TR:εδωκεν" src="14">he gave</w> <w  savlm="strong:G846 lemma.TR:αυτου" src="11">his</w> <w  savlm="strong:G3439 lemma.TR:μονογενη" src="13">only begotten</w> <w  savlm="strong:G3588 strong:G5207 lemma.TR:τον lemma.TR:υιον" src="9 10">Son</w>, <w  savlm="strong:G2443 lemma.TR:ινα" src="15">that</w> <w  savlm="strong:G3956 lemma.TR:πας" src="16">whosoever</w> <w  savlm="strong:G4100 lemma.TR:πιστευων" src="18">believeth</w> <w  savlm="strong:G1519 lemma.TR:εις" src="19">in</w> <w  savlm="strong:G846 lemma.TR:αυτον" src="20">him</w> <w  savlm="strong:G622 lemma.TR:αποληται" src="22" type="x-split-1793">should</w> <w  savlm="strong:G3361 lemma.TR:μη" src="21">not</w> <w  savlm="strong:G622 lemma.TR:αποληται" src="22" type="x-split-1793">perish</w>, <w  savlm="strong:G235 lemma.TR:αλλ" src="23">but</w> <w  savlm="strong:G2192 lemma.TR:εχη" src="24">have</w> <w  savlm="strong:G166 lemma.TR:αιωνιον" src="26">everlasting</w> <w  savlm="strong:G2222 lemma.TR:ζωην" src="25">life</w>.</q>  
```

After, it becomes:

> John 3:16: For God so loved the world, that he gave his only begotten Son, that whosoever believeth in him should not perish, but have everlasting life.

According to [the documentation](https://wiki.crosswire.org/Frontends:Diatheke), there is an 'output format' option which can be specified as plain text, but it doesn't appear to work.